### PR TITLE
Fix casting to int

### DIFF
--- a/include/unpacked.h
+++ b/include/unpacked.h
@@ -678,7 +678,7 @@ CONSTEXPR14 typename Trait::value_t Unpacked<FT, ET>::pack_xfixed() const
     // - exponent==-Trait::fraction_bits ==> 1 | 0
     // - exponent==intbits-1 ==> 0x8000000 | (F >> 1)
     ST r = (ST(1) << (exponent + Trait::fraction_bits)) |
-           (ST)(f >> (intbits - exponent));
+           (intbits - exponent < (signed)sizeof(f)*8 ? (ST)(f >> (intbits - exponent)) : 0);
     return negativeSign ? -r : r;
   }
 }


### PR DESCRIPTION
When the posit is 1.xxx, exponent is 0 so it would try to shift an uint32_t by 32, which is undefined behaviour

Reproducer:
```
int main() {
    Posit<int32_t, 32, 2, uint32_t, PositSpec::WithInf> x(1.01);
    std::cout << (int)x << std::endl;
}
```

CC: @danielecattaneo